### PR TITLE
Fix matplotlib NotImplementedError for axes aspect ratio.

### DIFF
--- a/SCRIPT/APSYNSIM3.py
+++ b/SCRIPT/APSYNSIM3.py
@@ -320,8 +320,8 @@ class Interferometer(object):
         self.dirtyPlot = self.figUV.add_subplot(236, aspect='equal')
 
         self.spherePlot = pl.axes([0.53, 0.82, 0.12, 0.12],
-                                  projection='3d',
-                                  aspect='equal')
+                                  projection='3d')
+        self.spherePlot.set_box_aspect([1., 1., 1.])
 
         u = np.linspace(0, 2 * np.pi, 100)
         v = np.linspace(0, np.pi, 100)


### PR DESCRIPTION
Heyo,

At some point in the past few years the Python 3 example script stopped worked (I see there's also a reference to this over on launchpad[0]).

This commit removes the `aspect = 'equal'` kwarg from the axes initialisation and instead sets it through the set_box_aspect call.

Cheers,
David

[0] https://bugs.launchpad.net/apsynsim/+bug/1952139